### PR TITLE
Fix big front dedupe log

### DIFF
--- a/frontend/tramvai.json
+++ b/frontend/tramvai.json
@@ -13,6 +13,7 @@
           },
           "configurations": {
             "sourceMap": true,
+            "dedupeIgnore": ["@platform-ui/"],
             "postcss": {
               "config": "src/mockingbird/postcss"
             }


### PR DESCRIPTION
### Problem

Deduplication of front packages has a very large log.

### Solution

Add ignore @platform-ui packages in deduplication.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@mockingbird/maintainers
