### PR TITLE
Trim strings

### DIFF
--- a/frontend/src/mockingbird/layers/pages/mock/utils.ts
+++ b/frontend/src/mockingbird/layers/pages/mock/utils.ts
@@ -66,7 +66,7 @@ export function mapFormDataToStub(
   const { name, labels, scope, times, method, path, isPathPattern } = data;
   return {
     ...mapPaths(path, isPathPattern, serviceId),
-    name,
+    name: name.trim(),
     labels,
     method,
     scope,
@@ -119,7 +119,7 @@ export function mapFormDataToScenario(
 ) {
   const { name, labels, scope, times, source, destination } = data;
   return {
-    name,
+    name: name.trim(),
     labels,
     scope,
     times: scope === 'countdown' ? times : undefined,
@@ -186,14 +186,14 @@ export function mapFormDataToGrpc(data: TGRPCFormData, serviceId: string) {
   } = data;
   const promises: any = [
     Promise.resolve({
-      name,
+      name: name.trim(),
       labels,
       scope,
       times: scope === 'countdown' ? times : undefined,
-      methodName,
-      requestClass,
+      methodName: methodName.trim(),
+      requestClass: requestClass.trim(),
       requestPredicates: parseJSON(data.requestPredicates),
-      responseClass,
+      responseClass: responseClass.trim(),
       response: parseJSON(data.response),
       state: parseJSON(data.state, true),
       seed: parseJSON(data.seed, true),
@@ -218,7 +218,7 @@ export function mapFormDataToGrpc(data: TGRPCFormData, serviceId: string) {
 function mapPaths(_path: string, isPattern: boolean, serviceId: string) {
   let path = null;
   let pathPattern = null;
-  const result = `/${serviceId}${_path}`;
+  const result = `/${serviceId}${_path.trim()}`;
   if (isPattern) pathPattern = result;
   else path = result;
   return {
@@ -283,7 +283,7 @@ function mapFormCallback(callback: TFormCallback): TCallBack {
     const res: TCallBackHTTP = {
       type: callback.type,
       request: parseJSON(callback.request),
-      delay: callback.delay || undefined,
+      delay: callback.delay?.trim() || undefined,
     };
     if (callback.responseMode) {
       res.responseMode = callback.responseMode;
@@ -296,7 +296,7 @@ function mapFormCallback(callback: TFormCallback): TCallBack {
       type: callback.type,
       destination: callback.destination,
       output: parseJSON(callback.output),
-      delay: callback.delay || undefined,
+      delay: callback.delay?.trim() || undefined,
     };
   }
   throw new Error('Missing callback type while mapping');

--- a/frontend/src/mockingbird/modules/destination/utils.ts
+++ b/frontend/src/mockingbird/modules/destination/utils.ts
@@ -31,8 +31,8 @@ export function mapFormDataToDestination(
 ): Destination {
   const { name, description } = data;
   return {
-    name,
-    description,
+    name: name.trim(),
+    description: description.trim(),
     service: serviceId,
     request: parseJSON(data.request),
     init: parseJSON(data.init, true),

--- a/frontend/src/mockingbird/modules/services/actions/createAction.ts
+++ b/frontend/src/mockingbird/modules/services/actions/createAction.ts
@@ -7,16 +7,23 @@ import {
   reset,
 } from '../reducers/createStore';
 
+
+type ServiceRequestParams = {
+  name: string,
+  suffix: string
+};
+
+
 export const createAction = createActionCore({
   name: 'CREATE_SERVICE_ACTION',
-  fn: ({ dispatch, getState }, body) => {
+  fn: ({ dispatch, getState }, body: ServiceRequestParams) => {
     dispatch(setLoading());
     const {
       environment: { MOCKINGBIRD_API },
     } = getState();
     return getJson(`${MOCKINGBIRD_API}/v2/service`, {
       httpMethod: 'post',
-      body,
+      body: normalizeRequest(body),
     })
       .then((response) => {
         const event =
@@ -28,6 +35,15 @@ export const createAction = createActionCore({
       .catch((e) => dispatch(createFail(e)));
   },
 });
+
+
+function normalizeRequest(params: ServiceRequestParams): ServiceRequestParams {
+  return {
+    name: params.name.trim(),
+    suffix: params.suffix.trim()
+  };
+}
+
 
 export const resetCreateStateAction = createActionCore({
   name: 'RESET_CREATE_SERVICE_ACTION',

--- a/frontend/src/mockingbird/modules/source/utils.ts
+++ b/frontend/src/mockingbird/modules/source/utils.ts
@@ -29,8 +29,8 @@ export function mapFormDataToSource(
 ): Source {
   const { name, description } = data;
   return {
-    name,
-    description,
+    name: name.trim(),
+    description: description.trim(),
     service: serviceId,
     request: parseJSON(data.request),
     init: parseJSON(data.init, true),


### PR DESCRIPTION
Fixes #22

### Problem

There was a problem when user can submit a string with spaces on both ends and it would be saved "as is" in MongoDB.

### Solution

This PR solves this problem by trimming those strings.

### Notes

Additional notes.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@mockingbird/maintainers
